### PR TITLE
OpenJDK is required before brewing out riot

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,12 @@ RIOT is a data import/export tool for Redis and Redis Modules that connects to f
 
 == Getting Started
 
+Pre-requsite:
+
+```
+$ brew cask install adoptopenjdk
+```
+
 === Homebrew 
 
 ```


### PR DESCRIPTION
Before installing riot on MacBook, OpenJDK is required.